### PR TITLE
fixed home tab executors dont get supported cuz it goes trough all of them

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -2552,8 +2552,10 @@ function Luna:CreateWindow(WindowSettings)
 			if isStudio then HomeTabPage.detailsholder.dashboard.Client.Subtitle.Text = "Luna Interface Suite - Debugging Mode" break end
 			if v == identifyexecutor() then
 				HomeTabPage.detailsholder.dashboard.Client.Subtitle.Text = "Your Executor Supports This Script."
+				break
 			else
 				HomeTabPage.detailsholder.dashboard.Client.Subtitle.Text = "Your Executor Isn't Officialy Supported By This Script."
+				break
 			end
 		end
 


### PR DESCRIPTION
basically for example i use solara
the list of supported is {"Fluxus", "Solara", "Xeno"}
it will go trough fluxus then solara then xeno but xeno is not what im using so it will say unsuported
this fix stops it from going any further if my executor is suported
so since my executor is solara it will stop at solara and say supported